### PR TITLE
Rebroadcasts: recommend adding a commit-message link to the original by using 'git cherry-pick -x'

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -114,7 +114,7 @@ git fetch <git name>
 - to repeat someone else's utterance:
 
 ```
-git cherry-pick <their commit hash>
+git cherry-pick -x <their commit hash>
 ```
 
 - [people to follow](https://github.com/diracdeltas/tweets/network/members)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ refresh:
 	git fetch --all
 
 repost:
-	git cherry-pick $(p)
+	git cherry-pick -x $(p)
 
 timeline-graph:
 	git log --graph --all --decorate --oneline


### PR DESCRIPTION
Doesn't guarantee that people will do this in practice, nor that the commit message itself hasn't been modified - but figured it could be worth suggesting anyway.