### PR TITLE
follow-everybody.bash: iterate over all forks using the page api param

### DIFF
--- a/follow-everybody.bash
+++ b/follow-everybody.bash
@@ -2,10 +2,19 @@
 
 # Copyright @datn 2022. Heavens forgive me for this
 # be in your repo dir for this
-for I in $(curl -H "Accept: application/vnd.github+json" https://api.github.com/repos/diracdeltas/tweets/forks | jq -r '.[].full_name')
-do  
-	user=$(echo "$I" | cut -d\/ -f1)
-	repo=$(echo "$I" | cut -d\/ -f2)
-	git remote add "$user" "https://github.com/$user/$repo"
-	git fetch "$user"
+declare -i page_num
+page_num=1
+
+while [[ $results_length != 0 ]];
+do
+  results=$(curl -H "Accept: application/vnd.github+json" "https://api.github.com/repos/diracdeltas/tweets/forks?per_page=100&page=$page_num")
+  results_length=$(echo $results | jq length)
+  for I in $(echo $results| jq -r '.[].full_name')
+  do  
+    user=$(echo "$I" | cut -d\/ -f1)
+    repo=$(echo "$I" | cut -d\/ -f2)
+    git remote add "$user" "https://github.com/$user/$repo"
+    git fetch "$user"
+  done
+  page_num=$((page_num+1))
 done


### PR DESCRIPTION
currently, the `follow-everybody.bash` script only tracks 30 forks, as is the default on the [fork endpoint](https://docs.github.com/pt/rest/repos/forks) of the gh api.

Ive added a simple iteration to keep increasing the `page` param until no results are found, meaning running the script once will track all existing forks (~120 at the time of writing).

cheers