### PR TITLE
Make all targets "phony"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: go everybody post refresh repost timeline
+.PHONY: everybody go post refresh repost timeline-graph timeline timeline-short
 
 everybody:
 	./follow-everybody.bash


### PR DESCRIPTION
The Makefile only has "phony" targets.
However, not all targets are marked as "phony".

This PR fixes that.