### PR TITLE
Use non-interactive 'git fetch' during timeline refresh

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -122,7 +122,7 @@ git cherry-pick -x <their commit hash>
 - to refresh your timeline and view it:
 
 ```
-git fetch --all && git rev-list --all --remotes --pretty | less
+GIT_TERMINAL_PROMPT=0 git fetch --all && git rev-list --all --remotes --pretty | less
 ```
 
 - some alternative ways to view your timeline (use `git show <commit hash>` to

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ post:
 	git push
 
 refresh:
-	git fetch --all
+	GIT_TERMINAL_PROMPT=0 git fetch --all
 
 repost:
 	git cherry-pick -x $(p)


### PR DESCRIPTION
This is one of at least a couple of possible ways to fix #12.

Worth noting: @guites had previously suggested an alternative approach at https://github.com/diracdeltas/tweets/issues/12#issuecomment-1305460820 which would involve a single HTTP request per remote -- basically to validate whether the forks listed by GitHub are accessible to the user before the fetch occurs.

It's kinda awkward to use an environment variable for this setting, but we can't (as far as I know, and probably sensibly by-design) make `git` infer it from any of the contents of the repository itself.  On the plus side, this should use fewer overall HTTP requests (`n` vs `2n`).

Resolves #12.