### PR TITLE
unfollow broken remotes on make refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ post:
 	git push
 
 refresh:
-	GIT_TERMINAL_PROMPT=0 git fetch --all
+	./refresh.bash
 
 repost:
 	git cherry-pick -x $(p)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ post:
 	git push
 
 refresh:
-	./refresh.bash
+	GIT_TERMINAL_PROMPT=0 ./refresh.bash
 
 repost:
 	git cherry-pick -x $(p)

--- a/refresh.bash
+++ b/refresh.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Copyright @guites 2022. I have no shame
+
+while read -r remote; do
+  echo "Fetching $remote"
+  GIT_TERMINAL_PROMPT=0 git fetch $remote
+  [ $? != 0 ] && git remote remove $remote
+done <<< "$(git remote)"


### PR DESCRIPTION
might be overkill but since `git fetch --all` actually refreshes the remotes one by one, i didn't notice any significant performance change.

this WILL fuck you up if you run `make refresh` without an internet connection though