### PR TITLE
Avoid adding existing remotes

### DIFF
--- a/follow-everybody.bash
+++ b/follow-everybody.bash
@@ -3,8 +3,23 @@
 # Copyright @datn 2022. Heavens forgive me for this
 # be in your repo dir for this
 
+# exits unsuccessfully if remote already exists
+# $1 is new remote name
+# $2 is new remote URL
+# $3 is list of your existing remotes
+add_new_remote() {
+    if grep -q "$1" <<< "$3"; then
+        false
+    else
+        git remote add "$1" "$2"
+    fi
+}
+
+# cache list of existing remotes
+remotes=$(git remote)
+
 # add yan's original repo so people have the staging branch
-git remote add diracdeltas https://github.com/diracdeltas/tweets/
+add_new_remote diracdeltas https://github.com/diracdeltas/tweets/ "$remotes" && git fetch diracdeltas
 
 declare -i page_num
 page_num=1
@@ -14,11 +29,10 @@ do
   results=$(curl -H "Accept: application/vnd.github+json" "https://api.github.com/repos/diracdeltas/tweets/forks?per_page=100&page=$page_num")
   results_length=$(echo $results | jq length)
   for I in $(echo $results| jq -r '.[].full_name')
-  do  
+  do
     user=$(echo "$I" | cut -d\/ -f1)
     repo=$(echo "$I" | cut -d\/ -f2)
-    git remote add "$user" "https://github.com/$user/$repo"
-    git fetch "$user"
+    add_new_remote "$user" "https://github.com/$user/$repo" "$remotes" && git fetch "$user"
   done
   page_num=$((page_num+1))
 done

--- a/refresh.bash
+++ b/refresh.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Copyright @guites 2022. I have no shame
+
+while read -r remote; do
+  echo "Fetching $remote"
+  GIT_TERMINAL_PROMPT=0 git fetch $remote
+  [ $? != 0 ] && git remote remove $remote
+done <<< "$(git remote)"


### PR DESCRIPTION
I wrote a simple check to speed up the follow-everybody script. It saves the list of existing remotes in a variable and skips running `git add remote user github.com/user/tweets/` if that user is already in the list.

New users will be `git fetch`ed, while existing remotes will not. I think this is good for separating concerns (if you want updates, run `make refresh`)

Seems like it speeds things up, also removes a lot of the error output.